### PR TITLE
Add files via upload

### DIFF
--- a/TodoApp/main/java/todo/application/controller/aop/CountAop.java
+++ b/TodoApp/main/java/todo/application/controller/aop/CountAop.java
@@ -2,15 +2,18 @@ package todo.application.controller.aop;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.annotation.AfterReturning;
 import org.aspectj.lang.annotation.Aspect;
 import org.springframework.stereotype.Component;
+import org.springframework.validation.BindingResult;
 import todo.application.controller.aop.annotation.countannotation.CreateCount;
 import todo.application.controller.aop.annotation.countannotation.JoinCount;
 import todo.application.controller.aop.annotation.countannotation.ReadCount;
 import todo.application.service.VisitorViewService;
 
 import javax.servlet.http.HttpServletRequest;
+import java.util.Arrays;
 import java.util.concurrent.ConcurrentHashMap;
 
 @Aspect
@@ -24,64 +27,43 @@ public class CountAop {
     //createCount가 있으면 write 하나씩 올린다.
 
     @AfterReturning("@annotation(createCount)")
-    public void countCreatedWrite(CreateCount createCount) {
-        log.info("Write Count add {} -> {}", visitorViewService.getWriteCreatedNumber().get(), visitorViewService.getWriteCreatedNumber().get() + 1L );
-        visitorViewService.addWriteCreatedNumber();
-    }
+    public void countCreatedWrite(JoinPoint joinPoint, CreateCount createCount) {
 
+        // Validation Check
+        boolean hasBindingResultError = checkBindingResultError(joinPoint);
+
+        // Validation 실패 시, CreatedWrite Count는 증가하지 않는다.
+        if (!hasBindingResultError){
+            log.info("Write Count add {} -> {}", visitorViewService.getWriteCreatedNumber().get(), visitorViewService.getWriteCreatedNumber().get() + 1L );
+            visitorViewService.addWriteCreatedNumber();
+        }
+    }
 
     @AfterReturning("@annotation(joinCount)")
-    public void countUserJoin(JoinCount joinCount) {
-        log.info("UserJoin Count add {} -> {}", visitorViewService.getUserJoin().get(), visitorViewService.getUserJoin().get() + 1L );
-        visitorViewService.adduserJoin();
-    }
+    public void countUserJoin(JoinPoint joinPoint, JoinCount joinCount) {
 
-    @AfterReturning("@annotation(readCount) && args(request)")
-    public void countView(HttpServletRequest request, ReadCount readCount) {
-        String clientIP = getClientIP(request);
+        // Validation Check
+        boolean hasBindingResultError = checkBindingResultError(joinPoint);
 
-
-
-
-    }
-
-
-
-
-    private String getClientIP(HttpServletRequest request) {
-        String ip = request.getHeader("X-Forwarded-For");
-        log.info("> X-FORWARDED-FOR : " + ip);
-
-        if (ip == null) {
-            ip = request.getHeader("Proxy-Client-IP");
-            log.info("> Proxy-Client-IP : " + ip);
+        // Validation 실패 시, UserJoin Count는 증가하지 않는다.
+        if(!hasBindingResultError){
+            log.info("UserJoin Count add {} -> {}", visitorViewService.getUserJoin().get(), visitorViewService.getUserJoin().get() + 1L );
+            visitorViewService.adduserJoin();
         }
-        if (ip == null) {
-            ip = request.getHeader("WL-Proxy-Client-IP");
-            log.info(">  WL-Proxy-Client-IP : " + ip);
-        }
-        if (ip == null) {
-            ip = request.getHeader("HTTP_CLIENT_IP");
-            log.info("> HTTP_CLIENT_IP : " + ip);
-        }
-        if (ip == null) {
-            ip = request.getHeader("HTTP_X_FORWARDED_FOR");
-            log.info("> HTTP_X_FORWARDED_FOR : " + ip);
-        }
-        if (ip == null) {
-            ip = request.getRemoteAddr();
-            log.info("> getRemoteAddr : "+ip);
-        }
-        log.info("> Result : IP Address : "+ip);
-
-        return ip;
     }
 
 
-
-
-
-
+    private boolean checkBindingResultError(JoinPoint joinPoint) {
+        boolean hasBindingResultError = false;
+        Object[] args = joinPoint.getArgs();
+        for (Object arg : args) {
+            if (arg instanceof BindingResult) {
+                BindingResult temp = (BindingResult) arg;
+                hasBindingResultError  = temp.hasErrors();
+            }
+        }
+        return hasBindingResultError;
+    }
 
 
 }


### PR DESCRIPTION
[기능 개선] Count AOP 정상 동작 추가
- BindingResult가 에러가 있을 때, Exception이 발생하지 않기 때문에 AOP는 항상 Count를 증가시켜줬음.
- 정상 동작을 위해 JoinPoint 인스턴스에서 BindingResult 인스턴스를 받고, 인스턴스가 있을 경우 에러 체크하는 Validation을 추가했음.